### PR TITLE
Add a missing `#` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Some quick Example:
 # search wildcard
 /command.*swiper/
 
-a b matches lines with a and b
+a b # matches lines with a and b
 a !b # matches lines with a but not b
 
 /lint|display/ # lint OR display


### PR DESCRIPTION
This extension looks really nice, I just started trying it. Saw a missing `#` in the readme and thought I would fix it